### PR TITLE
fix: clarify Resend response usage (use data.data.id)

### DIFF
--- a/src/components/contact/contact.tsx
+++ b/src/components/contact/contact.tsx
@@ -93,7 +93,7 @@ export default function Contact() {
         body: JSON.stringify({ name, email, message, recaptcha_token }),
       });
       const data = await res.json();
-      if (!data.id)
+      if (!data.data.id)
         throw {
           title: "Failed to send message",
           description: data.error ?? "Something went wrong",


### PR DESCRIPTION
Previously, you get an error when you try to send an email. The response is nested, like  { data: { id: '.....' }, error: null } so it has to be data.data.id.